### PR TITLE
Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ spirit of those in Clojure <code>core</code> and Haskell's <code>Prelude</code>.
 <li><p><code>atria::variant</code> provides tools for better usability of
 <a href="http://www.boost.org/doc/libs/1_58_0/doc/html/variant.html">Boost.Variant</a>
 and <a href="http://eggs-cpp.github.io/variant/">Eggs.Variant</a> and is
-customizable to other sum type implementatios.</p></li>
+customizable to other sum type implementations.</p></li>
 <li><p><code>atria::meta</code> provides several metaprogramming tools, including some
 <a href="http://www.boost.org/doc/libs/1_59_0/libs/mpl/doc/index.html">Booost.MPL</a>
 adaptors for several variadic types and concept checking facilities.</p></li>


### PR DESCRIPTION
`implementatios` -> `implementations`
