### PR TITLE
Reduce cross module dependencies

### DIFF
--- a/src/atria/estd/functional.hpp
+++ b/src/atria/estd/functional.hpp
@@ -99,29 +99,32 @@ ABL_DEFINE_CPP14_OPERATOR_1(bit_not, ~)
 
 namespace detail {
 
+#define ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN(body_expr)  \
+  decltype(body_expr) { return (body_expr); }
+
 template <class F, class... Args>
 inline auto INVOKE(F&& f, Args&&... args)
-  -> ABL_DECLTYPE_RETURN(
+  -> ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN(
     std::forward<F>(f)(std::forward<Args>(args)...))
 
 template <class Base, class T, class Derived>
 inline auto INVOKE(T Base::*pmd, Derived&& ref)
-  -> ABL_DECLTYPE_RETURN(
+  -> ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN(
     std::forward<Derived>(ref).*pmd)
 
 template <class PMD, class Pointer>
 inline auto INVOKE(PMD pmd, Pointer&& ptr)
-  -> ABL_DECLTYPE_RETURN(
+  -> ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN(
     (*std::forward<Pointer>(ptr)).*pmd)
 
 template <class Base, class T, class Derived, class... Args>
 inline auto INVOKE(T Base::*pmf, Derived&& ref, Args&&... args)
--> ABL_DECLTYPE_RETURN(
+-> ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN(
   (std::forward<Derived>(ref).*pmf)(std::forward<Args>(args)...))
 
 template <class PMF, class Pointer, class... Args>
 inline auto INVOKE(PMF pmf, Pointer&& ptr, Args&&... args)
-  -> ABL_DECLTYPE_RETURN(
+  -> ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN(
     ((*std::forward<Pointer>(ptr)).*pmf)(std::forward<Args>(args)...))
 
 } // namespace detail
@@ -131,8 +134,10 @@ inline auto INVOKE(PMF pmf, Pointer&& ptr, Args&&... args)
  */
 template <class F, class... ArgTypes>
 auto invoke(F&& f, ArgTypes&&... args)
-  -> ABL_DECLTYPE_RETURN(
+  -> ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN(
     detail::INVOKE(std::forward<F>(f), std::forward<ArgTypes>(args)...))
+
+#undef ABL_ESTD_FUNCTIONAL_DECLTYPE_RETURN
 
 } // namespace estd
 } // namespace atria

--- a/src/atria/estd/functional.hpp
+++ b/src/atria/estd/functional.hpp
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <functional>
-#include <atria/meta/utils.hpp>
 
 namespace atria {
 namespace estd {

--- a/src/atria/estd/type_traits.hpp
+++ b/src/atria/estd/type_traits.hpp
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <atria/meta/utils.hpp>
 #include <type_traits>
 
 namespace atria {

--- a/src/atria/funken/detail/access.hpp
+++ b/src/atria/funken/detail/access.hpp
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <atria/estd/type_traits.hpp>
+#include <atria/meta/utils.hpp>
 #include <utility>
 
 namespace atria {

--- a/src/atria/meta/copy_traits.hpp
+++ b/src/atria/meta/copy_traits.hpp
@@ -33,7 +33,7 @@ namespace atria {
 namespace meta {
 
 /*!
- * Metafunction that given a metafunction `TraitChekMf` to check
+ * Metafunction that given a metafunction `TraitCheckMf` to check
  * whether a type has a trait, and another `TraitAddMf` to add it to a
  * type, returns `TraitAddMf<DestT>` if `TraitCheckMf<OrigT>`, else
  * `OrigT`.

--- a/src/atria/meta/tst_concepts.cpp
+++ b/src/atria/meta/tst_concepts.cpp
@@ -76,14 +76,14 @@ TEST(simple_concept, can_be_evaluated_like_aconcept_lite)
 {
   EXPECT_TRUE(Example_concept<example_model>());
   // This is expected to fail to compile
-  //   EXPECT_FALSE(Example_concept<ExampleNonModel>());
+  //   EXPECT_FALSE(Example_concept<example_non_model>());
 }
 
 TEST(simple_concept, can_be_used_with_concept_assert)
 {
   ABL_ASSERT_CONCEPT(Example_concept, example_model);
   // This is expected to fail to compile
-  //   ABL_ASSERT_CONCEPT(Example_concept, ExampleNonModel);
+  //   ABL_ASSERT_CONCEPT(Example_concept, example_non_model);
 }
 
 /*!
@@ -131,12 +131,12 @@ TEST(concept, can_use_check_with_concept_spec)
   EXPECT_TRUE(check<Example_concept_two_spec(example_model)>());
   // This should fail to compiler, rising an error in the line of
   // the specification that is not met.
-  //   EXPECT_FALSE(check<Example_concept_two<void>(ExampleNonModel)>());
+  //   EXPECT_FALSE(check<Example_concept_two<void>(example_non_model)>());
 }
 
 /*!
  * Finally, an example of specifying a SFINAE-friendly concept in two
- * steps, which migth seem clearer to some.
+ * steps, which might seem clearer to some.
  */
 struct Example_concept_spec
 {

--- a/src/atria/testing/benchmark.cpp
+++ b/src/atria/testing/benchmark.cpp
@@ -24,6 +24,8 @@
 #include <atria/xform/transducer/map.hpp>
 #include <atria/xform/transduce.hpp>
 
+#include <atria/meta/utils.hpp>
+
 #include <ableton/build_system/Warnings.hpp>
 ABL_DISABLE_WARNINGS
 #include <cxxopts.hpp>

--- a/src/atria/testing/benchmark.cpp
+++ b/src/atria/testing/benchmark.cpp
@@ -21,8 +21,6 @@
 //
 
 #include <atria/testing/benchmark.hpp>
-#include <atria/xform/transducer/map.hpp>
-#include <atria/xform/transduce.hpp>
 
 #include <atria/meta/utils.hpp>
 
@@ -50,15 +48,11 @@ benchmark_suite_base::~benchmark_suite_base()
   std::cout << std::endl << name_ << " --" << std::endl;
   if (!results_.empty()) {
     auto best_time  = std::get<0>(*results_.begin());
-    auto name_width = xform::transduce(
-      xform::map([] (std::tuple<double, std::string> item) {
-        return std::get<1>(item).size();
-      }),
-      [] (std::size_t acc, std::size_t next) {
-        return std::max(acc, next);
-      },
-      std::size_t{},
-      results_);
+    auto name_width = std::accumulate(
+      results_.begin(), results_.end(), size_t(0),
+      [](size_t width, const std::tuple<double, std::string>& item) {
+        return std::max(std::get<1>(item).size(), width);
+      });
 
     for (auto& result : results_) {
       auto& time = std::get<0>(result);

--- a/src/atria/xform/any_state.hpp
+++ b/src/atria/xform/any_state.hpp
@@ -30,6 +30,7 @@
 #include <atria/xform/state_traits.hpp>
 #include <atria/estd/memory.hpp>
 #include <atria/meta/pack.hpp>
+#include <atria/meta/utils.hpp>
 #include <string>
 #include <stdexcept>
 

--- a/src/atria/xform/impure/transducer/enumerate.hpp
+++ b/src/atria/xform/impure/transducer/enumerate.hpp
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <atria/xform/transducer_impl.hpp>
+#include <atria/meta/utils.hpp>
 
 namespace atria {
 namespace xform {

--- a/src/atria/xform/state_traits.hpp
+++ b/src/atria/xform/state_traits.hpp
@@ -28,6 +28,7 @@
 
 #include <atria/estd/type_traits.hpp>
 #include <atria/estd/utility.hpp>
+#include <atria/meta/utils.hpp>
 
 namespace atria {
 namespace xform {

--- a/src/atria/xform/transducer/enumerate.hpp
+++ b/src/atria/xform/transducer/enumerate.hpp
@@ -29,6 +29,7 @@
 #include <atria/xform/transducer_impl.hpp>
 #include <atria/xform/state_wrapper.hpp>
 #include <atria/prelude/constantly.hpp>
+#include <atria/meta/utils.hpp>
 
 namespace atria {
 namespace xform {


### PR DESCRIPTION
This changes the dependency tree of the repo to
1. Remove circular dependency between `estd` and `meta`
2. Move `testing` to only depend on `estd`

Current:
![image](https://cloud.githubusercontent.com/assets/8038876/14379704/b06aa08e-fd7b-11e5-8d4b-bdb42b3fd45d.png)

Proposed:
![image](https://cloud.githubusercontent.com/assets/8038876/14379719/c09ccf5e-fd7b-11e5-9008-989c92da3fe0.png)

Also fixes a couple of typos.

RFC
Juan Pedro Bolívar Puente (@arximboldi)
Tobias Hahn (@toh-ableton)
Stephan Bots (@sbs-ableton)
